### PR TITLE
Unity 6 で閉じるボタンが表示されない不具合を修正

### DIFF
--- a/Assets/MasyoLab/FavoritesAsset/Editor/Core/Const.cs
+++ b/Assets/MasyoLab/FavoritesAsset/Editor/Core/Const.cs
@@ -45,7 +45,12 @@ namespace MasyoLab.Editor.FavoritesAsset
         /// <summary>
         /// 閉じるアイコン
         /// </summary>
-        public const string ICON_CLOSE = "winbtn_win_close";
+        public const string ICON_CLOSE
+#if UNITY_6000_0_OR_NEWER
+            = "d_clear@2x";
+#else
+            = "winbtn_win_close";
+#endif
 
         /// <summary>
         /// FolderAdded


### PR DESCRIPTION
Unity 6 で、閉じるボタンのアイコンに `d_clear@2x` を使用するように変更しました。